### PR TITLE
Improve the movie title pattern matching regex

### DIFF
--- a/actorle_solver.py
+++ b/actorle_solver.py
@@ -61,22 +61,37 @@ def get_actors_in_movies(performances_dataframe, movie_ids):
     return matching_actors[['nconst', 'characters']]
 
 
-def make_regex(movie_title_pattern):
+def make_movie_title_regex(movie_title_pattern):
     words = movie_title_pattern.split()
     regex_pattern = ""
-    character_pattern = "[a-zA-Z0-9:\\'&-\.]"
     for index, word in enumerate(words):
-        regex_pattern += "{}{{{}}}".format(character_pattern, len(word))
+        regex_pattern += make_movie_title_word_regex(word)
         if index != len(words) - 1:
             regex_pattern += " "
     regex_pattern += "$"
     return regex_pattern
 
 
+def make_movie_title_word_regex(movie_title_word):
+    count = 0
+    word_regex = ''
+    title_character_pattern = "[a-zA-Z0-9]"
+    for character in movie_title_word:
+        if character.isalnum():
+            count += 1
+        else:
+            word_regex += "{}{{{}}}".format(title_character_pattern, count)
+            word_regex += "\\{}".format(character)
+            count = 0
+    if count == len(movie_title_word):
+        word_regex += "{}{{{}}}".format(title_character_pattern, count)
+    return word_regex
+
+
 def get_matching_movie_ids(titles_data_frame, movie_clue):
     titles_data_frame = titles_data_frame[titles_data_frame.startYear == movie_clue.year]
     print("Filtered down to {} movies from the year {}".format(titles_data_frame.shape[0], movie_clue.year))
-    match_pattern = make_regex(movie_clue.title_pattern)
+    match_pattern = make_movie_title_regex(movie_clue.title_pattern)
     query = "primaryTitle.str.match('{}')".format(match_pattern)
     print("Filtering remaining movies with query '{}'".format(query))
     results = titles_data_frame.query(query)


### PR DESCRIPTION
Fixes #1 

## Before - spurious matches due to overly generic movie title regex

- `xxxxxx-xxx: xxxxxxxxxx`: **7** Movies, **19** Actors
- `xxxxxxxx: xxxxxxx`: **31** Movies, **87** Actors
- `xxxxxx-xxx: xx xxx xxxx`: **2** Movies, **12** Actors

```shell
...
Looking for movie matches for MovieClue(title_pattern='xxxxxx-xxx: xxxxxxxxxx', year='2017', genre_list='Action,Adventure,Science Fiction,Drama', score=7.4)
Filtered down to 18656 movies from the year 2017
Filtering remaining movies with query 'primaryTitle.str.match('[a-zA-Z0-9:\'&-\.]{11} [a-zA-Z0-9:\'&-\.]{10}$')'
7 Matches for pattern 'xxxxxx-xxx: xxxxxxxxxx', year 2017 (Sample: ['Mountaintop Experiment', 'Everything, Everything', 'Socialmente pericolosi'])
Found 19 actors for these 7 movie_ids
----------------------------
Looking for movie matches for MovieClue(title_pattern='xxxxxxxx: xxxxxxx', year='2019', genre_list='Adventure,Science Fiction,Action', score=8.4)
Filtered down to 18510 movies from the year 2019
Filtering remaining movies with query 'primaryTitle.str.match('[a-zA-Z0-9:\'&-\.]{9} [a-zA-Z0-9:\'&-\.]{7}$')'
31 Matches for pattern 'xxxxxxxx: xxxxxxx', year 2019 (Sample: ['Katharine Hepburn', 'Abandoned Mansion', 'Happiness Machine'])
Found 87 actors for these 31 movie_ids
----------------------------
Looking for movie matches for MovieClue(title_pattern='xxxxxx-xxx: xx xxx xxxx', year='2021', genre_list='Action,Adventure,Science Fiction', score=8.2)
Filtered down to 18000 movies from the year 2021
Filtering remaining movies with query 'primaryTitle.str.match('[a-zA-Z0-9:\'&-\.]{11} [a-zA-Z0-9:\'&-\.]{2} [a-zA-Z0-9:\'&-\.]{3} [a-zA-Z0-9:\'&-\.]{4}$')'
2 Matches for pattern 'xxxxxx-xxx: xx xxx xxxx', year 2021 (Sample: ['Spider-Man: No Way Home', 'Heartprints in the Snow'])
Found 12 actors for these 2 movie_ids
----------------------------
...
Made a list of 5,917 individual movie performances from all the clues


Actor IDs occurring most often across all possible candidate movies:[('nm4043618', 7), ('nm0000375', 5), ('nm0000616', 5)]
```

## After - much narrower sets of movie title matches

- `xxxxxx-xxx: xxxxxxxxxx`: **1** Movie, **4** Actors
- `xxxxxxxx: xxxxxxx`: **2** Movies, **4** Actors
- `xxxxxx-xxx: xx xxx xxxx`: **1** Movie, **4** Actors

```shell
...
Looking for movie matches for MovieClue(title_pattern='xxxxxx-xxx: xxxxxxxxxx', year='2017', genre_list='Action,Adventure,Science Fiction,Drama', score=7.4)
Filtered down to 18656 movies from the year 2017
Filtering remaining movies with query 'primaryTitle.str.match('[a-zA-Z0-9]{6}\-[a-zA-Z0-9]{3}\: [a-zA-Z0-9]{10}$')'
1 Matches for pattern 'xxxxxx-xxx: xxxxxxxxxx', year 2017 (Sample: ['Spider-Man: Homecoming'])
Found 4 actors for these 1 movie_ids
----------------------------
Looking for movie matches for MovieClue(title_pattern='xxxxxxxx: xxxxxxx', year='2019', genre_list='Adventure,Science Fiction,Action', score=8.4)
Filtered down to 18510 movies from the year 2019
Filtering remaining movies with query 'primaryTitle.str.match('[a-zA-Z0-9]{8}\: [a-zA-Z0-9]{7}$')'
2 Matches for pattern 'xxxxxxxx: xxxxxxx', year 2019 (Sample: ['Avengers: Endgame', 'RiffTrax: Feeders'])
Found 4 actors for these 2 movie_ids
----------------------------
Looking for movie matches for MovieClue(title_pattern='xxxxxx-xxx: xx xxx xxxx', year='2021', genre_list='Action,Adventure,Science Fiction', score=8.2)
Filtered down to 18000 movies from the year 2021
Filtering remaining movies with query 'primaryTitle.str.match('[a-zA-Z0-9]{6}\-[a-zA-Z0-9]{3}\: [a-zA-Z0-9]{2} [a-zA-Z0-9]{3} [a-zA-Z0-9]{4}$')'
1 Matches for pattern 'xxxxxx-xxx: xx xxx xxxx', year 2021 (Sample: ['Spider-Man: No Way Home'])
Found 4 actors for these 1 movie_ids
----------------------------
...

Made a list of 5,639 individual movie performances from all the clues


Actor IDs occurring most often across all possible candidate movies:[('nm4043618', 7), ('nm0000375', 5), ('nm0000616', 5)]
```